### PR TITLE
chore: upgrade libp2p record version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "debug": "^3.1.0",
     "err-code": "^1.1.2",
     "interface-datastore": "~0.4.2",
-    "libp2p-record": "~0.5.1"
+    "libp2p-record": "~0.6.0"
   },
   "devDependencies": {
     "aegir": "^15.1.0",


### PR DESCRIPTION
The `libp2p-record` module was updated to interop with `go-libp2p-record`.  As a result, the author and signature were removed, as well as all the logic inherent to the signature.

More info [js-libp2p-record#8](https://github.com/libp2p/js-libp2p-record/pull/8)