### PR TITLE
fix: libp2p record with no author

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Arguments:
 - `validator` (Object): containing validate function and select function.
 - `subscriptionKeyFn` (function): function to manipulate the key topic received according to the needs, as well as to block the message received to be published.
 
-Note: `validator` object must be composed by two functions, `validate (data, peerId, callback)` and `select (receivedRecod, currentRecord, callback)`. `validate` aims to verify if a new record received by pubsub is valid to be stored locally by the node. If it is valid and the node already has a local record stored, `select` is the function provided to be responsible for deciding which record is the best (newer) between the already stored and the received through pubsub. A `validator` example can be found at: TODO (js-ipns)
+Note: `validator` object must be composed by two functions, `validate (data, key, callback)` and `select (receivedRecod, currentRecord, callback)`. `validate` aims to verify if a new record received by pubsub is valid to be stored locally by the node. If it is valid and the node already has a local record stored, `select` is the function provided to be responsible for deciding which record is the best (newer) between the already stored and the received through pubsub. A `validator` example can be found at: TODO (js-ipns)
 
 ```js
 const dsPubsub = new DatastorePubsub(pubsub, datastore, peerId, validator)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Arguments:
 - `validator` (Object): containing validate function and select function.
 - `subscriptionKeyFn` (function): function to manipulate the key topic received according to the needs, as well as to block the message received to be published.
 
-Note: `validator` object must be composed by two functions, `validate (data, key, callback)` and `select (receivedRecod, currentRecord, callback)`. `validate` aims to verify if a new record received by pubsub is valid to be stored locally by the node. If it is valid and the node already has a local record stored, `select` is the function provided to be responsible for deciding which record is the best (newer) between the already stored and the received through pubsub. A `validator` example can be found at: TODO (js-ipns)
+Note: `validator` object must be composed by two functions, `validate (data, key, callback)` and `select (receivedRecord, currentRecord, callback)`. `validate` aims to verify if a new record received by pubsub is valid to be stored locally by the node. If it is valid and the node already has a local record stored, `select` is the function provided to be responsible for deciding which record is the best (newer) between the already stored and the received through pubsub. A `validator` example can be found at: TODO (js-ipns)
 
 ```js
 const dsPubsub = new DatastorePubsub(pubsub, datastore, peerId, validator)

--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,7 @@ class DatastorePubsub {
     }
 
     // validate received record
-    this._validateRecord(receivedRecord.value, receivedRecord.author, (err, valid) => {
+    this._validateRecord(receivedRecord.value, key, (err, valid) => {
       // If not valid, it is not better than the one currently available
       if (err || !valid) {
         const errMsg = 'record received through pubsub is not valid'


### PR DESCRIPTION
Since `libp2p-record` does not have author (removed for interop with `go-ipfs`), `validateRecord` must find the peerId, using the key (`/ipns/{peer_id}`)