### PR TITLE
chore: differentiate datastore errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "libp2p-record": "~0.6.0"
   },
   "devDependencies": {
-    "aegir": "^15.1.0",
-    "chai": "^4.1.2",
+    "aegir": "^17.1.0",
+    "chai": "^4.2.0",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
-    "ipfs": "~0.31.5",
-    "ipfsd-ctl": "~0.39.1",
+    "ipfs": "~0.33.1",
+    "ipfsd-ctl": "~0.40.0",
     "sinon": "^7.0.0"
   },
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -129,10 +129,16 @@ class DatastorePubsub {
 
     this._datastore.get(routingKey, (err, dsVal) => {
       if (err) {
+        if (err.code !== 'ERR_NOT_FOUND') {
+          const errMsg = `unexpected error getting the ipns record for ${routingKey.toString()}`
+
+          log.error(errMsg)
+          return callback(errcode(new Error(errMsg), 'ERR_UNEXPECTED_ERROR_GETTING_RECORD'))
+        }
         const errMsg = `local record requested was not found for ${routingKey.toString()}`
 
         log.error(errMsg)
-        return callback(errcode(new Error(errMsg), 'ERR_NO_LOCAL_RECORD_FOUND'))
+        return callback(errcode(new Error(errMsg), 'ERR_NOT_FOUND'))
       }
 
       if (!Buffer.isBuffer(dsVal)) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -123,6 +123,7 @@ describe('datastore-pubsub', function () {
 
       dsPubsubA.get(key, (err) => {
         expect(err).to.exist() // not locally stored record
+        expect(err.code).to.equal('ERR_NOT_FOUND')
 
         pubsubA.ls((err, res) => {
           expect(err).to.not.exist()
@@ -488,6 +489,19 @@ describe('datastore-pubsub', function () {
 
         done()
       })
+    })
+  })
+
+  it('should handle a unexpected error properly when getting from the datastore', function (done) {
+    const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
+    const stub = sinon.stub(dsPubsubA._datastore, 'get').callsArgWith(1, { code: 'RANDOM_ERR' })
+
+    dsPubsubA.get(key, (err) => {
+      expect(err).to.exist() // not locally stored record
+      expect(err.code).to.equal('ERR_UNEXPECTED_ERROR_GETTING_RECORD')
+
+      stub.restore()
+      done()
     })
   })
 })


### PR DESCRIPTION
We should differentiate datastore errors from `Not found error` and an `unexpected error`