### PR TITLE
feat: support all type of records

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,9 @@
   "dependencies": {
     "assert": "^1.4.1",
     "base32.js": "~0.1.0",
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "err-code": "^1.1.2",
-    "interface-datastore": "~0.4.2",
-    "libp2p-record": "~0.6.0"
+    "interface-datastore": "~0.6.0"
   },
   "devDependencies": {
     "aegir": "^17.1.0",
@@ -46,7 +45,8 @@
     "dirty-chai": "^2.0.1",
     "ipfs": "~0.33.1",
     "ipfsd-ctl": "~0.40.0",
-    "sinon": "^7.0.0"
+    "libp2p-record": "~0.6.1",
+    "sinon": "^7.1.1"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@ua.pt>",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -155,6 +155,49 @@ describe('datastore-pubsub', function () {
     })
   })
 
+  it('should validate if record content is the same', function (done) {
+    const customValidator = {
+      validate: (data, peerId, callback) => {
+        const receivedRecord = Record.deserialize(data)
+
+        expect(receivedRecord.value.toString()).to.equal(value) // validator should deserialize correctly
+        callback(null, receivedRecord.value.toString() === value)
+      },
+      select: (receivedRecod, currentRecord, callback) => {
+        callback(null, 0)
+      }
+    }
+    const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
+    const dsPubsubB = new DatastorePubsub(pubsubB, datastoreB, peerIdB, customValidator)
+    const topic = `/${keyRef}`
+    let receivedMessage = false
+
+    function messageHandler () {
+      receivedMessage = true
+    }
+
+    dsPubsubB.get(key, (err, res) => {
+      expect(err).to.exist()
+      expect(res).to.not.exist() // not value available, but subscribed now
+
+      series([
+        (cb) => waitForPeerToSubscribe(topic, ipfsdBId, ipfsdA, cb),
+        // subscribe in order to understand when the message arrive to the node
+        (cb) => pubsubB.subscribe(topic, messageHandler, cb),
+        (cb) => dsPubsubA.put(key, serializedRecord, cb),
+        // wait until message arrives
+        (cb) => waitFor(() => receivedMessage === true, cb),
+        // get from datastore
+        (cb) => dsPubsubB.get(key, cb)
+      ], (err, res) => {
+        // No record received, in spite of message received
+        expect(err).to.not.exist() // message was discarded as a result of failing the validation
+        expect(res[4]).to.exist()
+        done()
+      })
+    })
+  })
+
   it('should put correctly to daemon A and daemon B should receive it as it tried to get it first and subscribed it', function (done) {
     const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
     const dsPubsubB = new DatastorePubsub(pubsubB, datastoreB, peerIdB, smoothValidator)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -178,7 +178,7 @@ describe('datastore-pubsub', function () {
 
     dsPubsubB.get(key, (err, res) => {
       expect(err).to.exist()
-      expect(res).to.not.exist() // not value available, but subscribed now
+      expect(res).to.not.exist() // no value available, but subscribed now
 
       series([
         (cb) => waitForPeerToSubscribe(topic, ipfsdBId, ipfsdA, cb),
@@ -190,8 +190,7 @@ describe('datastore-pubsub', function () {
         // get from datastore
         (cb) => dsPubsubB.get(key, cb)
       ], (err, res) => {
-        // No record received, in spite of message received
-        expect(err).to.not.exist() // message was discarded as a result of failing the validation
+        expect(err).to.not.exist()
         expect(res[4]).to.exist()
         done()
       })


### PR DESCRIPTION
PR for supporting all types of records, instead of only `libp2p-record`

BREAKING CHANGE: validators have to deserialize the data (if using libp2p-record)