### PR TITLE
chore: use multibase instead of base32.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   "homepage": "https://github.com/ipfs/js-datastore-pubsub#readme",
   "dependencies": {
     "assert": "^1.4.1",
-    "base32.js": "~0.1.0",
     "debug": "^4.1.0",
     "err-code": "^1.1.2",
-    "interface-datastore": "~0.6.0"
+    "interface-datastore": "~0.6.0",
+    "multibase": "~0.6.0"
   },
   "devDependencies": {
     "aegir": "^17.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,10 @@ class DatastorePubsub {
    * @memberof DatastorePubsub
    */
   constructor (pubsub, datastore, peerId, validator, subscriptionKeyFn) {
-    assert.equal(typeof validator, 'object', 'missing validator')
-    assert.equal(typeof validator.validate, 'function', 'missing validate function')
-    assert.equal(typeof validator.select, 'function', 'missing select function')
-    subscriptionKeyFn && assert.equal(typeof subscriptionKeyFn, 'function', 'invalid subscriptionKeyFn received')
+    assert.strictEqual(typeof validator, 'object', 'missing validator')
+    assert.strictEqual(typeof validator.validate, 'function', 'missing validate function')
+    assert.strictEqual(typeof validator.select, 'function', 'missing select function')
+    subscriptionKeyFn && assert.strictEqual(typeof subscriptionKeyFn, 'function', 'invalid subscriptionKeyFn received')
 
     this._pubsub = pubsub
     this._datastore = datastore

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const base32 = require('base32.js')
+const multibase = require('multibase')
 
 module.exports.encodeBase32 = (buf) => {
-  const enc = new base32.Encoder()
-  return enc.write(buf).finalize()
+  return multibase.encode('base32', buf).slice(1) // slice off multibase codec
 }


### PR DESCRIPTION
Use `multibase` instead of `base32.js` for computing the base32 of a buffer. 