### PR TITLE
fix: topicToKey should return a buffer not a string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ class DatastorePubsub {
       return
     }
 
-    log(`message received for ${key} topic`)
+    log(`message received for topic ${topicIDs[0]}`)
 
     // Stop if the message is from the peer (it already stored it while publishing to pubsub)
     if (from === this._peerId.toB58String()) {
@@ -269,7 +269,7 @@ class DatastorePubsub {
     const routingKey = new Key('/' + encodeBase32(key), false)
 
     await this._datastore.put(routingKey, data)
-    log(`record for ${key.toString()} was stored in the datastore`)
+    log(`record for ${keyToTopic(key)} was stored in the datastore`)
   }
 
   open () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,5 +27,5 @@ module.exports.topicToKey = (topic) => {
 
   const key = `${base64urlCode}${topic.substring(namespace.length)}`
 
-  return multibase.decode(key).toString()
+  return multibase.decode(key)
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,7 +13,7 @@ const { Key } = require('interface-datastore')
 const { Record } = require('libp2p-record')
 
 const DatastorePubsub = require('../src')
-const { keyToTopic } = require('../src/utils')
+const { keyToTopic, topicToKey } = require('../src/utils')
 const { connect, waitFor, waitForPeerToSubscribe, spawnDaemon, stopDaemon } = require('./utils')
 const promisify = require('promisify-es6')
 
@@ -426,8 +426,8 @@ describe('datastore-pubsub', function () {
   })
 
   it('should subscribe the topic and after a message being received, discard it using the subscriptionKeyFn', async () => {
-    const subscriptionKeyFn = (topic) => {
-      expect(topic).to.equal(`/${keyRef}`)
+    const subscriptionKeyFn = (key) => {
+      expect(key.toString()).to.equal(`/${keyRef}`)
       throw new Error('DISCARD MESSAGE')
     }
     const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
@@ -469,14 +469,14 @@ describe('datastore-pubsub', function () {
   })
 
   it('should subscribe the topic and after a message being received, change its key using subscriptionKeyFn', async () => {
-    const subscriptionKeyFn = (topic) => {
-      expect(topic).to.equal(key.toString())
-      return `${topic}new`
+    const subscriptionKeyFn = (key) => {
+      expect(key.toString()).to.equal(`/${keyRef}`)
+      return topicToKey(`${keyToTopic(key)}new`)
     }
     const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
     const dsPubsubB = new DatastorePubsub(pubsubB, datastoreB, peerIdB, smoothValidator, subscriptionKeyFn)
     const subsTopic = keyToTopic(`/${keyRef}`)
-    const keyNew = Buffer.from(`${key.toString()}new`)
+    const keyNew = topicToKey(`${keyToTopic(key)}new`)
     let receivedMessage = false
 
     function messageHandler () {


### PR DESCRIPTION
Also, `Buffer.toString()` without specifying an encoding can result in unprintable characters being part of the string which can result in false positives when comparing stringified buffers.

E.g:

```javascript
Buffer.from([254]).toString() === Buffer.from([253]).toString()
// true

Buffer.from([254]).toString('hex') === Buffer.from([253]).toString('hex')
// false
```

Also, also, stop putting stringified buffers into the logs because it can corrupt your console output.