### PR TITLE
fix: pubsub.ls changed to pubsub.getTopics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ class DatastorePubsub {
     }
 
     const stringifiedTopic = keyToTopic(key)
-    const subscriptions = await this._pubsub.ls()
+    const subscriptions = await this._pubsub.getTopics()
 
     // If already subscribed, just try to get it
     if (subscriptions && Array.isArray(subscriptions) && subscriptions.indexOf(stringifiedTopic) > -1) {


### PR DESCRIPTION
I don't know how to fix the tests. This module _should not_ depend on js-ipfs! Note that in the next version `_repo` and `_peerInfo` properties will not be available on a js-ipfs instance so there will be more problems.