### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
     "libp2p-gossipsub": "^0.4.5",
-    "libp2p-record": "~0.7.3",
+    "libp2p-record": "^0.7.3",
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.13.13",
     "sinon": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "buffer": "^5.6.0",
     "debug": "^4.1.1",
-    "err-code": "^2.0.0",
-    "interface-datastore": "^1.0.2",
+    "err-code": "^2.0.3",
+    "interface-datastore": "^1.0.4",
     "multibase": "^0.7.0"
   },
   "devDependencies": {
@@ -44,11 +44,10 @@
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
-    "libp2p-gossipsub": "^0.3.0",
-    "libp2p-record": "^0.7.0",
+    "libp2p-gossipsub": "^0.4.5",
+    "libp2p-record": "~0.7.3",
     "p-wait-for": "^3.1.0",
-    "peer-id": "^0.13.6",
-    "peer-info": "^0.17.5",
+    "peer-id": "^0.13.13",
     "sinon": "^9.0.2"
   },
   "contributors": [

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -57,8 +57,8 @@ describe('datastore-pubsub', function () {
       createPubsubNode(registrarRecordA),
       createPubsubNode(registrarRecordB)
     ])
-    peerIdA = pubsubA.peerInfo.id
-    peerIdB = pubsubB.peerInfo.id
+    peerIdA = pubsubA.peerId
+    peerIdB = pubsubB.peerId
 
     await connectPubsubNodes(
       {


### PR DESCRIPTION
Updating dependencies with the latest gossipsub without no `peer-info`, as well as adding the `handle` call for the peers as the streams are unidirectional now