### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Try to subscribe a topic with Pubsub and receive the current local value if avai
 
 Arguments:
 
-- `key` (Buffer): a key representing a unique identifier of the object to subscribe.
+- `key` (Uint8Array): a key representing a unique identifier of the object to subscribe.
 
-Returns `Promise<Buffer>` containing the most recent known record stored.
+Returns `Promise<Uint8Array>` containing the most recent known record stored.
 
 #### Put
 
@@ -89,8 +89,8 @@ Publishes a value through pubsub.
 
 Arguments:
 
-- `key` (Buffer): a key representing a unique identifier of the object to publish.
-- `val` (Buffer): value to be propagated.
+- `key` (Uint8Array): a key representing a unique identifier of the object to publish.
+- `val` (Uint8Array): value to be propagated.
 
 Returns `Promise<void>`
 
@@ -104,7 +104,7 @@ Unsubscribe a previously subscribe value.
 
 Arguments:
 
-- `key` (Buffer): a key representing a unique identifier of the object to publish.
+- `key` (Uint8Array): a key representing a unique identifier of the object to publish.
 
 Returns `Promise<void>`
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ipfs-utils": "^2.3.1",
     "it-pair": "^1.0.0",
     "libp2p-gossipsub": "^0.4.5",
-    "libp2p-record": "libp2p/js-libp2p-record#fix/support-uint8arrays-in-place-of-buffers",
+    "libp2p-record": "^0.8.0",
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.13.13",
     "sinon": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -32,20 +32,18 @@
   },
   "homepage": "https://github.com/ipfs/js-datastore-pubsub#readme",
   "dependencies": {
-    "buffer": "^5.6.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.3",
-    "interface-datastore": "^1.0.4",
-    "multibase": "^0.7.0"
+    "interface-datastore": "ipfs/interface-datastore#fix/remove-node-buffer",
+    "multibase": "^2.0.0"
   },
   "devDependencies": {
     "aegir": "^25.0.0",
-    "chai": "^4.2.0",
     "detect-node": "^2.0.4",
-    "dirty-chai": "^2.0.1",
+    "ipfs-utils": "^2.3.1",
     "it-pair": "^1.0.0",
     "libp2p-gossipsub": "^0.4.5",
-    "libp2p-record": "^0.7.3",
+    "libp2p-record": "libp2p/js-libp2p-record#fix/support-uint8arrays-in-place-of-buffers",
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.13.13",
     "sinon": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "err-code": "^2.0.3",
-    "interface-datastore": "ipfs/interface-datastore#fix/remove-node-buffer",
+    "interface-datastore": "^2.0.0",
     "multibase": "^2.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const { Key, Adapter } = require('interface-datastore')
 const { encodeBase32, keyToTopic, topicToKey } = require('./utils')
 
@@ -54,20 +53,20 @@ class DatastorePubsub extends Adapter {
 
   /**
    * Publishes a value through pubsub.
-   * @param {Buffer} key identifier of the value to be published.
-   * @param {Buffer} val value to be propagated.
+   * @param {Uint8Array} key identifier of the value to be published.
+   * @param {Uint8Array} val value to be propagated.
    * @returns {Promise}
    */
   async put (key, val) { // eslint-disable-line require-await
-    if (!Buffer.isBuffer(key)) {
+    if (!(key instanceof Uint8Array)) {
       const errMsg = 'datastore key does not have a valid format'
 
       log.error(errMsg)
       throw errcode(new Error(errMsg), 'ERR_INVALID_DATASTORE_KEY')
     }
 
-    if (!Buffer.isBuffer(val)) {
-      const errMsg = 'received value is not a buffer'
+    if (!(val instanceof Uint8Array)) {
+      const errMsg = 'received value is not a Uint8Array'
 
       log.error(errMsg)
       throw errcode(new Error(errMsg), 'ERR_INVALID_VALUE_RECEIVED')
@@ -83,11 +82,11 @@ class DatastorePubsub extends Adapter {
 
   /**
    * Try to subscribe a topic with Pubsub and returns the local value if available.
-   * @param {Buffer} key identifier of the value to be subscribed.
-   * @returns {Promise<Buffer>}
+   * @param {Uint8Array} key identifier of the value to be subscribed.
+   * @returns {Promise<Uint8Array>}
    */
   async get (key) {
-    if (!Buffer.isBuffer(key)) {
+    if (!(key instanceof Uint8Array)) {
       const errMsg = 'datastore key does not have a valid format'
 
       log.error(errMsg)
@@ -118,7 +117,7 @@ class DatastorePubsub extends Adapter {
 
   /**
    * Unsubscribe topic.
-   * @param {Buffer} key identifier of the value to unsubscribe.
+   * @param {Uint8Array} key identifier of the value to unsubscribe.
    * @returns {void}
    */
   unsubscribe (key) {
@@ -148,7 +147,7 @@ class DatastorePubsub extends Adapter {
       throw errcode(new Error(errMsg), 'ERR_NOT_FOUND')
     }
 
-    if (!Buffer.isBuffer(dsVal)) {
+    if (!(dsVal instanceof Uint8Array)) {
       const errMsg = 'found record that we couldn\'t convert to a value'
 
       log.error(errMsg)
@@ -210,7 +209,7 @@ class DatastorePubsub extends Adapter {
     }
 
     if (isBetter) {
-      await this._storeRecord(Buffer.from(key), data)
+      await this._storeRecord(key, data)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -250,7 +250,7 @@ class DatastorePubsub extends Adapter {
     let currentRecord
 
     try {
-      currentRecord = await this._getLocal(dsKey.toBuffer())
+      currentRecord = await this._getLocal(dsKey.uint8Array())
     } catch (err) {
       // if the old one is invalid, the new one is *always* better
       return true

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,10 @@
 
 const multibase = require('multibase')
 const errcode = require('err-code')
+const TextEncoder = require('ipfs-utils/src/text-encoder')
+const TextDecoder = require('ipfs-utils/src/text-decoder')
+const utf8Encoder = new TextEncoder('utf8')
+const utf8Decoder = new TextDecoder('utf8')
 
 const namespace = '/record/'
 const base64urlCode = 'u' // base64url code from multibase
@@ -14,7 +18,11 @@ module.exports.encodeBase32 = (buf) => {
 module.exports.keyToTopic = (key) => {
   // Record-store keys are arbitrary binary. However, pubsub requires UTF-8 string topic IDs
   // Encodes to "/record/base64url(key)"
-  const b64url = multibase.encode('base64url', key).slice(1).toString()
+  if (typeof key === 'string' || key instanceof String) {
+    key = utf8Encoder.encode(key)
+  }
+
+  const b64url = utf8Decoder.decode(multibase.encode('base64url', key).slice(1))
 
   return `${namespace}${b64url}`
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -82,7 +82,7 @@ describe('datastore-pubsub', function () {
   // prepare Record
   beforeEach(() => {
     keyRef = `key${testCounter}`
-    key = (new Key(keyRef)).toBuffer()
+    key = (new Key(keyRef)).uint8Array()
     record = new Record(key, utf8Encoder.encode(value))
 
     serializedRecord = record.serialize()


### PR DESCRIPTION
Pulls in the latest interface-datastore and replaces use of node
Buffers with Uint8Arrays

Depends on:

- [x] https://github.com/ipfs/interface-datastore/pull/43
- [x] https://github.com/ipfs/js-datastore-core/pull/27
- [x] https://github.com/libp2p/js-libp2p-record/pull/23