### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,17 +35,16 @@
     "debug": "^4.1.1",
     "err-code": "^2.0.3",
     "interface-datastore": "^2.0.0",
-    "multibase": "^2.0.0"
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^26.0.0",
     "detect-node": "^2.0.4",
-    "ipfs-utils": "^2.3.1",
     "it-pair": "^1.0.0",
     "libp2p-gossipsub": "^0.5.0",
     "libp2p-record": "^0.9.0",
     "p-wait-for": "^3.1.0",
-    "peer-id": "^0.13.13",
+    "peer-id": "^0.14.0",
     "sinon": "^9.0.2"
   },
   "contributors": [

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,17 +1,13 @@
 'use strict'
 
-const multibase = require('multibase')
 const errcode = require('err-code')
-const TextEncoder = require('ipfs-utils/src/text-encoder')
-const TextDecoder = require('ipfs-utils/src/text-decoder')
-const utf8Encoder = new TextEncoder('utf8')
-const utf8Decoder = new TextDecoder('utf8')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const namespace = '/record/'
-const base64urlCode = 'u' // base64url code from multibase
 
 module.exports.encodeBase32 = (buf) => {
-  return multibase.encode('base32', buf).slice(1) // slice off multibase codec
+  return uint8ArrayToString(buf, 'base32')
 }
 
 // converts a binary record key to a pubsub topic key.
@@ -19,10 +15,10 @@ module.exports.keyToTopic = (key) => {
   // Record-store keys are arbitrary binary. However, pubsub requires UTF-8 string topic IDs
   // Encodes to "/record/base64url(key)"
   if (typeof key === 'string' || key instanceof String) {
-    key = utf8Encoder.encode(key)
+    key = uint8ArrayFromString(key)
   }
 
-  const b64url = utf8Decoder.decode(multibase.encode('base64url', key).slice(1))
+  const b64url = uint8ArrayToString(key, 'base64url')
 
   return `${namespace}${b64url}`
 }
@@ -33,7 +29,7 @@ module.exports.topicToKey = (topic) => {
     throw errcode(new Error('topic received is not from a record'), 'ERR_TOPIC_IS_NOT_FROM_RECORD_NAMESPACE')
   }
 
-  const key = `${base64urlCode}${topic.substring(namespace.length)}`
+  const key = topic.substring(namespace.length)
 
-  return multibase.decode(key)
+  return uint8ArrayFromString(key, 'base64url')
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,8 +5,8 @@ const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
 const errcode = require('err-code')
 const isNode = require('detect-node')
-const TextEncoder = require('ipfs-utils/src/text-encoder')
-const utf8Encoder = new TextEncoder('utf8')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const DatastorePubsub = require('../src')
 
@@ -83,7 +83,7 @@ describe('datastore-pubsub', function () {
   beforeEach(() => {
     keyRef = `key${testCounter}`
     key = (new Key(keyRef)).uint8Array()
-    record = new Record(key, utf8Encoder.encode(value))
+    record = new Record(key, uint8ArrayFromString(value))
 
     serializedRecord = record.serialize()
   })
@@ -320,7 +320,7 @@ describe('datastore-pubsub', function () {
     }
 
     const newValue = 'new value'
-    const record = new Record(key, utf8Encoder.encode(newValue))
+    const record = new Record(key, uint8ArrayFromString(newValue))
     const newSerializedRecord = record.serialize()
 
     const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
@@ -370,7 +370,7 @@ describe('datastore-pubsub', function () {
     }
 
     const newValue = 'new value'
-    const record = new Record(key, utf8Encoder.encode(newValue))
+    const record = new Record(key, uint8ArrayFromString(newValue))
     const newSerializedRecord = record.serialize()
 
     const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
@@ -419,7 +419,7 @@ describe('datastore-pubsub', function () {
 
   it('should subscribe the topic and after a message being received, discard it using the subscriptionKeyFn', async () => {
     const subscriptionKeyFn = (key) => {
-      expect(key.toString()).to.equal(`/${keyRef}`)
+      expect(uint8ArrayToString(key)).to.equal(`/${keyRef}`)
       throw new Error('DISCARD MESSAGE')
     }
     const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
@@ -462,7 +462,7 @@ describe('datastore-pubsub', function () {
 
   it('should subscribe the topic and after a message being received, change its key using subscriptionKeyFn', async () => {
     const subscriptionKeyFn = (key) => {
-      expect(key.toString()).to.equal(`/${keyRef}`)
+      expect(uint8ArrayToString(key)).to.equal(`/${keyRef}`)
       return topicToKey(`${keyToTopic(key)}new`)
     }
     const dsPubsubA = new DatastorePubsub(pubsubA, datastoreA, peerIdA, smoothValidator)
@@ -497,8 +497,7 @@ describe('datastore-pubsub', function () {
     // get from datastore
     const result = await dsPubsubB.get(keyNew)
     const receivedRecord = Record.deserialize(result)
-
-    expect(receivedRecord.value.toString()).to.equal(value)
+    expect(uint8ArrayToString(receivedRecord.value)).to.equal(value)
   })
 
   it('should subscribe a topic only once', async () => {


### PR DESCRIPTION
Updates aegir and peer-ids, swaps multibase for uint8arrays as it's only used to turn uint8arrays into strings and back.