### PR TITLE
chore: add types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: node_js
 cache: npm
+dist: bionic
+
+branches:
+  only:
+  - master
+  - /^release\/.*$/
+
+node_js:
+  - 'lts/*'
+  - 'node'
 
 stages:
   - check
-  - test
-  - cov
-
-node_js:
-  - '10'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "it-pair": "^1.0.0",
     "libp2p": "^0.30.9",
     "libp2p-gossipsub": "^0.8.0",
+    "libp2p-interfaces": "^0.8.3",
     "libp2p-record": "^0.10.0",
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.14.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "prepare": "aegir build --no-bundle",
-    "prepublishOnly": "aegir build",
     "lint": "aegir lint",
     "release": "aegir release --target node",
     "release-minor": "aegir release --target node --type minor",
@@ -26,6 +25,10 @@
     "ipfs",
     "datastore",
     "pubsub"
+  ],
+  "files": [
+    "dist",
+    "src"
   ],
   "author": "Vasco Santos <vasco.santos@moxy.studio>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Responsible for providing an interface-datastore compliant api to pubsub",
   "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "main": "src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "aegir build",
+    "prepare": "aegir build --no-bundle",
+    "prepublishOnly": "aegir build",
     "lint": "aegir lint",
     "release": "aegir release --target node",
     "release-minor": "aegir release --target node --type minor",
@@ -38,8 +40,12 @@
     "uint8arrays": "^2.0.5"
   },
   "devDependencies": {
+    "@types/detect-node": "^2.0.0",
+    "@types/mocha": "^8.2.1",
+    "@types/sinon": "^9.0.10",
     "aegir": "^31.0.3",
     "detect-node": "^2.0.4",
+    "ipfs-core-types": "^0.3.0",
     "it-pair": "^1.0.0",
     "libp2p": "^0.30.9",
     "libp2p-gossipsub": "^0.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ class DatastorePubsub extends Adapter {
    * @param {import('interface-datastore').Datastore} datastore - datastore instance
    * @param {PeerId} peerId - peer-id instance
    * @param {Validator} validator - validator functions
-   * @param {SubscriptionKeyFn} [subscriptionKeyFn] - optional function to manipulate the key topic received before processing it
+   * @param {SubscriptionKeyFn} [subscriptionKeyFn] - function to manipulate the key topic received before processing it
    * @memberof DatastorePubsub
    */
   constructor (pubsub, datastore, peerId, validator, subscriptionKeyFn) {

--- a/src/index.js
+++ b/src/index.js
@@ -64,10 +64,9 @@ class DatastorePubsub extends Adapter {
    *
    * @param {Uint8Array} key - identifier of the value to be published.
    * @param {Uint8Array} val - value to be propagated.
-   * @returns {Promise<void>}
    */
   // @ts-ignore Datastores take keys as Keys, this one takes Uint8Arrays
-  async put (key, val) { // eslint-disable-line require-await
+  async put (key, val) {
     if (!(key instanceof Uint8Array)) {
       const errMsg = 'datastore key does not have a valid format'
 
@@ -87,7 +86,7 @@ class DatastorePubsub extends Adapter {
     log(`publish value for topic ${stringifiedTopic}`)
 
     // Publish record to pubsub
-    return this._pubsub.publish(stringifiedTopic, val)
+    await this._pubsub.publish(stringifiedTopic, val)
   }
 
   /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,11 @@
+import { Key } from 'interface-datastore'
+import PeerId from 'peer-id'
+
+type ValidateFn = (record: Uint8Array, peerId: Uint8Array) => boolean
+type CompareFn = (received: Uint8Array, current: Uint8Array) => number
+export type SubscriptionKeyFn = (key: Uint8Array) => Promise<Uint8Array>
+
+export interface Validator {
+  validate: ValidateFn,
+  select: CompareFn
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,7 @@
 import { Key } from 'interface-datastore'
 import PeerId from 'peer-id'
 
-type ValidateFn = (record: Uint8Array, peerId: Uint8Array) => boolean
+type ValidateFn = (record: Uint8Array, peerId: Uint8Array) => Promise<boolean> | boolean
 type CompareFn = (received: Uint8Array, current: Uint8Array) => number
 export type SubscriptionKeyFn = (key: Uint8Array) => Promise<Uint8Array>
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,3 @@
-import { Key } from 'interface-datastore'
-import PeerId from 'peer-id'
 
 type ValidateFn = (record: Uint8Array, peerId: Uint8Array) => Promise<boolean> | boolean
 type CompareFn = (received: Uint8Array, current: Uint8Array) => number

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,7 @@
 
 type ValidateFn = (record: Uint8Array, peerId: Uint8Array) => Promise<boolean> | boolean
 type CompareFn = (received: Uint8Array, current: Uint8Array) => number
-export type SubscriptionKeyFn = (key: Uint8Array) => Promise<Uint8Array>
+export type SubscriptionKeyFn = (key: Uint8Array) => Promise<Uint8Array> | Uint8Array
 
 export interface Validator {
   validate: ValidateFn,

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,18 +4,29 @@ const errcode = require('err-code')
 const uint8ArrayToString = require('uint8arrays/to-string')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
+/**
+ * @typedef {import('interface-datastore').Key} Key
+ */
+
 const namespace = '/record/'
 
-module.exports.encodeBase32 = (buf) => {
+/**
+ * @param {Uint8Array} buf
+ */
+function encodeBase32 (buf) {
   return uint8ArrayToString(buf, 'base32')
 }
 
-// converts a binary record key to a pubsub topic key.
-module.exports.keyToTopic = (key) => {
+/**
+ * converts a binary record key to a pubsub topic key
+ *
+ * @param {Uint8Array | string} key
+ */
+function keyToTopic (key) {
   // Record-store keys are arbitrary binary. However, pubsub requires UTF-8 string topic IDs
   // Encodes to "/record/base64url(key)"
   if (typeof key === 'string' || key instanceof String) {
-    key = uint8ArrayFromString(key)
+    key = uint8ArrayFromString(key.toString())
   }
 
   const b64url = uint8ArrayToString(key, 'base64url')
@@ -23,8 +34,12 @@ module.exports.keyToTopic = (key) => {
   return `${namespace}${b64url}`
 }
 
-// converts a pubsub topic key to a binary record key.
-module.exports.topicToKey = (topic) => {
+/**
+ * converts a pubsub topic key to a binary record key
+ *
+ * @param {string} topic
+ */
+function topicToKey (topic) {
   if (topic.substring(0, namespace.length) !== namespace) {
     throw errcode(new Error('topic received is not from a record'), 'ERR_TOPIC_IS_NOT_FROM_RECORD_NAMESPACE')
   }
@@ -32,4 +47,10 @@ module.exports.topicToKey = (topic) => {
   const key = topic.substring(namespace.length)
 
   return uint8ArrayFromString(key, 'base64url')
+}
+
+module.exports = {
+  encodeBase32,
+  keyToTopic,
+  topicToKey
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./node_modules/aegir/src/config/tsconfig.aegir.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist"
   },
   "include": [
-    "src"
+    "src",
+    "test"
   ]
 }


### PR DESCRIPTION
Needs a bit of sanity checking as this datastore appears to require
`Uint8Arrays` as keys when every other datastore takes `Keys` as keys.

Does not type the tests because they use lots of libp2p primitives
and the types there need a bit of work still.